### PR TITLE
Sync Gersbach Hep cleanser config compute-resource fixes to lineage-atlas snapshot

### DIFF
--- a/CRISPRi_lineage_atlas/config/v0.0.1/Gersbach_WTC11-hepatocyte-differentiation_TF-Perturb-seq.config
+++ b/CRISPRi_lineage_atlas/config/v0.0.1/Gersbach_WTC11-hepatocyte-differentiation_TF-Perturb-seq.config
@@ -159,7 +159,11 @@ profiles {
             batch.maxSpotAttempts = 5
             httpReadTimeout = '1800 s'
             httpConnectTimeout = '600 s'
-            batch.bootDiskSize = 100.GB
+            // 47-sub-pool dataset: anndata_concat writes 47 temp_processed/processed_N.h5ad
+            // to the task disk before the final concat, overflowing the default 100 GB
+            // ("No space left on device", died at file 44/47). 500 GB covers the 47 temp
+            // files + the combined object. (Benchmark configs got away with 100 GB at ~28 sub-pools.)
+            batch.bootDiskSize = 500.GB
         }
         workDir = "${params.google_bucket}/work"
         singularity.cacheDir = "${params.google_bucket}/singularity-cache"
@@ -174,11 +178,29 @@ process {
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
 
-    withName: 'downloadGTF|downloadGenome|skipGenomeDownload|skipGTFDownload|anndata_concat|createGuideRef|createHashingRef|seqSpecCheck|createDashboard_HASHING|createDashboard|createDashboard_HASHING_default|createDashboard_default|CreateMuData_HASHING|CreateMuData|demultiplex|doublets_scrub|downloadReference|filter_hashing|hashing_concat|prepare_assignment|mudata_concat|inference_mudata|prepare_guide_inference|prepare_user_guide_inference|prepare_all_guide_inference|PreprocessAnnData|seqSpecParser|prepare_covariate|mergedResults|publishFiles|mergeMudata|evaluation_plot|evaluation_undefined_plot|evaluation_plot_default|evaluation_undefined_plot_default' {
+    withName: 'downloadGTF|downloadGenome|skipGenomeDownload|skipGTFDownload|anndata_concat|createGuideRef|createHashingRef|seqSpecCheck|createDashboard_HASHING|createDashboard|createDashboard_HASHING_default|createDashboard_default|CreateMuData_HASHING|CreateMuData|demultiplex|doublets_scrub|filter_hashing|hashing_concat|prepare_assignment|mudata_concat|inference_mudata|prepare_guide_inference|prepare_user_guide_inference|prepare_all_guide_inference|PreprocessAnnData|seqSpecParser|prepare_covariate|mergedResults|publishFiles|mergeMudata|evaluation_plot|evaluation_undefined_plot|evaluation_plot_default|evaluation_undefined_plot_default' {
         container = params.containers.base
         cpus = { Math.min(4 * task.attempt, params.max_cpus) }
         memory = { [50.GB * task.attempt, params.max_memory].min() }
-        machineType = { workflow.profile == 'google' ? 'n2-highmem-16' : null }
+        // n2-highmem-32 = 32 vCPU / 256 GB. The retry-scaled memory (50GB×attempt,
+        // up to 200 GB at attempt 4) overflows n2-highmem-16's 128 GB, which GCP
+        // rejects as "machine_type cannot satisfy compute_resource". 32 covers all attempts.
+        machineType = { workflow.profile == 'google' ? 'n2-highmem-32' : null }
+        errorStrategy = 'retry'
+        maxRetries = 3
+    }
+
+    // PreprocessAnnData loads the full concatenated_adata.h5ad (110 GiB on disk for Hep's
+    // 47 sub-pools) and runs QC filtering + plots. It OOM-killed (exit 137, "Killed") at
+    // EVERY retry up to the broad block's 200 GB ceiling, so it needs >200 GB. Override to
+    // a 512 GB machine (n2-highmem-64) with a higher memory ceiling than max_memory(256).
+    // Hon CM's analogous override only reaches n2-highmem-32/256 GB — enough for its ~28
+    // sub-pools, not Hep's 47. If this still OOMs, escalate to n2-highmem-80 (640 GB) or m1-ultramem.
+    withName: 'PreprocessAnnData' {
+        container = params.containers.base
+        cpus = { Math.min(8 * task.attempt, params.max_cpus) }
+        memory = { [320.GB * task.attempt, 480.GB].min() }
+        machineType = { workflow.profile == 'google' ? 'n2-highmem-64' : null }
         errorStrategy = 'retry'
         maxRetries = 3
     }

--- a/datasets/Gersbach_WTC11-hepatocyte-differentiation_TF-Perturb-seq/setup/configs/Gersbach_WTC11-hepatocyte-differentiation_TF-Perturb-seq_cleanser_initial.config
+++ b/datasets/Gersbach_WTC11-hepatocyte-differentiation_TF-Perturb-seq/setup/configs/Gersbach_WTC11-hepatocyte-differentiation_TF-Perturb-seq_cleanser_initial.config
@@ -190,6 +190,21 @@ process {
         maxRetries = 3
     }
 
+    // PreprocessAnnData loads the full concatenated_adata.h5ad (110 GiB on disk for Hep's
+    // 47 sub-pools) and runs QC filtering + plots. It OOM-killed (exit 137, "Killed") at
+    // EVERY retry up to the broad block's 200 GB ceiling, so it needs >200 GB. Override to
+    // a 512 GB machine (n2-highmem-64) with a higher memory ceiling than max_memory(256).
+    // Hon CM's analogous override only reaches n2-highmem-32/256 GB — enough for its ~28
+    // sub-pools, not Hep's 47. If this still OOMs, escalate to n2-highmem-80 (640 GB) or m1-ultramem.
+    withName: 'PreprocessAnnData' {
+        container = params.containers.base
+        cpus = { Math.min(8 * task.attempt, params.max_cpus) }
+        memory = { [320.GB * task.attempt, 480.GB].min() }
+        machineType = { workflow.profile == 'google' ? 'n2-highmem-64' : null }
+        errorStrategy = 'retry'
+        maxRetries = 3
+    }
+
     withName: 'mappingGuide|mappingHashing|mappingscRNA' {
         container = params.containers.base
         cpus = { Math.min(8 * task.attempt, params.max_cpus) }


### PR DESCRIPTION
## What

Commits and propagates the three compute-resource fixes that got the **Gersbach WTC11 hepatocyte** `cleanser_initial` run (`2026_06_10`) past its failure points. These were live in the as-run `setup/configs` file but **uncommitted** and **not mirrored** into the `CRISPRi_lineage_atlas/config` snapshot — they'd be lost on a clean checkout.

## Fixes captured

| Stage | Change | Why |
|---|---|---|
| `anndata_concat` | boot disk **100 → 500 GB** | 47 sub-pools wrote `temp_processed/*.h5ad` to the task disk; overflowed 100 GB, died at file 44/47 (`No space left on device`) |
| shared `withName` block | **n2-highmem-16 → n2-highmem-32** | retry-scaled memory (`50GB×attempt`, up to 200 GB) overflowed the -16's 128 GB; GCP rejected as `machine_type cannot satisfy compute_resource` |
| `PreprocessAnnData` (new override) | **n2-highmem-64 / `320GB×attempt` cap 480** | loads the ~110 GiB concatenated AnnData; OOM-killed (exit 137) at every retry up to the 200 GB ceiling on Hep's 47 pools |

## Files

- `datasets/Gersbach…/setup/configs/…_cleanser_initial.config` — commits the previously-uncommitted as-run config
- `CRISPRi_lineage_atlas/config/v0.0.1/Gersbach…config` — verbatim copy so the lineage snapshot matches what ran

Hon CM was already in sync (its lineage copy already carried the analogous PreprocessAnnData → n2-highmem-32 fix). Guide assignment itself completed (47/47); the run's actual wall is downstream at inference — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)